### PR TITLE
remove extra --env

### DIFF
--- a/detail-docs/conda.md
+++ b/detail-docs/conda.md
@@ -21,8 +21,8 @@ Conda packages are found in
 life easier for you if you configure your Conda to use a few useful channels:
 
 ```
-conda config --add --env channels conda-forge
-conda config --add --env channels bioconda
+conda config --add channels conda-forge
+conda config --add channels bioconda
 ```
 
 ## Creating an environment


### PR DESCRIPTION
the old command was incorrect and gave the following error:
`conda config: error: argument --prepend/--add: expected 2 arguments`